### PR TITLE
Fix linker errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ project(MINI_SPD)
 
 set (CMAKE_CXX_STANDARD 17)
 
+# This fixes a weird "invalid version number in '-mmacosx-version-min=11.1'" error
+# when using Xcode.
+set (CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
+
 find_package(ROOT REQUIRED)
 
 set(INCLUDE_DIRECTORIES
@@ -22,5 +26,7 @@ link_directories( ${LINK_DIRECTORIES})
 add_executable(minispd main.cpp)
 
 target_sources(minispd PUBLIC src/DataTaking.cpp src/BmnSiliconDigit.cxx)
+
+ROOT_GENERATE_DICTIONARY(G__BmnSiliconDigit BmnSiliconDigit.h MODULE minispd)
 
 target_link_libraries(minispd Core RIO Tree Hist)


### PR DESCRIPTION
Таки нужно генерировать словарь, в нём появляются определения некоторых методов класса `BmnSiliconDigit`, на отсутствие которых как раз жаловался линковщик.